### PR TITLE
Add pinned dependencies and update setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ A Python scraper for tracking startups dealflow.
 ## Getting Started
 
 1. Clone the repository
-2. Install dependencies: `pip install -r requirements.txt`
-3. Run the scraper: `python scraper.py`
+2. (Recommended) Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install dependencies: `pip install -r requirements.txt`
+4. Run the scraper: `python scraper.py`
 
 ## Purpose
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.31.0
+beautifulsoup4==4.12.2
+pandas==2.1.4


### PR DESCRIPTION
## Summary
- add a requirements.txt file with pinned versions for the scraper's dependencies
- document using a virtual environment before installing the dependency file

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dad30cadfc8326a4bed895be851304