### PR TITLE
Align scraper output with Vaireo schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,37 @@ Enable `--dry-run` to execute the workflow without writing results to disk. This
 is helpful when iterating on new parsers. Pair it with `--log-level DEBUG` to
 inspect parsing output and HTTP requests in real time.
 
+## Output schema
+
+Each record emitted by the scraper follows the Vaireo dealflow schema below.
+The field names are aligned with the spreadsheet you provided so that the JSON
+output can be ingested without additional mapping.
+
+| Campo                     | Descripción                                                                 |
+|---------------------------|-----------------------------------------------------------------------------|
+| `id`                      | Identificador único de la startup (si la fuente lo expone).                 |
+| `nombre`                  | Nombre de la startup.                                                       |
+| `sector`                  | Sector principal en el que opera.                                           |
+| `sub_sector`              | Subsector o categoría específica.                                           |
+| `pais`                    | País de origen.                                                             |
+| `estado`                  | Estado o etapa actual (por ejemplo, seed, growth).                          |
+| `descripcion`             | Resumen de la propuesta de valor.                                           |
+| `website`                 | URL oficial de la compañía.                                                 |
+| `tags`                    | Lista de etiquetas libres asociadas a la startup.                           |
+| `tecnologia_principal`    | Tecnología central que impulsa la solución.                                 |
+| `eficiencia_hidrica`      | Indicador relacionado con eficiencia en el uso de agua.                     |
+| `tecnologias_regenerativas` | Tecnologías regenerativas aplicadas.                                      |
+| `impacto_medioambiental`  | Resumen del impacto medioambiental positivo.                                |
+| `impacto_social`          | Descripción del impacto social.                                             |
+| `modelo_digital`          | Información sobre el modelo digital del negocio.                            |
+| `indicador_sostenibilidad`| Métrica o señal de sostenibilidad reportada por la fuente.                  |
+| `fuente_datos`            | Nombre de la fuente que aportó la información.                              |
+| `scraped_at`              | Marca temporal (epoch) del momento de recolección.                          |
+
+Los campos que no estén presentes en la fuente se normalizan como cadenas
+vacías (`""`), salvo `tags`, que siempre es una lista. Esto facilita integrar
+datos provenientes de fuentes heterogéneas.
+
 ## Extending the scraper
 
 To add a new source:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-requests==2.31.0
-beautifulsoup4==4.12.2
-pandas==2.1.4
+# This project currently relies on the Python standard library only.
+# Keep this file to make it easy to introduce third-party packages later.


### PR DESCRIPTION
## Summary
- normalise parsed records to the full Vaireo dealflow field list and coerce tag data
- update the sample parser to map both English and Spanish payload keys to the schema
- document the JSON schema in the README and clarify that no third-party requirements are needed

## Testing
- python - <<'PY'
from scraper import normalise_deal
sample = {
    "id": 123,
    "nombre": "Ejemplo",
    "tags": ["agua", "impacto"],
    "fuente_datos": "sample",
}
print(normalise_deal(sample))
PY


------
https://chatgpt.com/codex/tasks/task_e_68dad20ba7ac83269143949da3c16714